### PR TITLE
Fix result details retrieval; handle URL hash update when closing results

### DIFF
--- a/apps/validation_framework_v2/src/Introduction.js
+++ b/apps/validation_framework_v2/src/Introduction.js
@@ -128,20 +128,20 @@ function MediaCard(props) {
               />
             </div>
           </CardContent>
-          <CardActions style={{ marginLeft: 5, marginRight: 5 }}>
-            <Button
-              size="small"
-              color="primary"
-              style={{ fontWeight: "bolder" }}
-              onClick={() => {
-                updateHash("model_id." + props.id);
-                window.location.reload();
-              }}
-            >
-              View Model
-            </Button>
-          </CardActions>
         </CardActionArea>
+        <CardActions style={{ marginLeft: 5, marginRight: 5 }}>
+          <Button
+            size="small"
+            color="primary"
+            style={{ fontWeight: "bolder" }}
+            onClick={() => {
+              updateHash("model_id." + props.id);
+              window.location.reload();
+            }}
+          >
+            View Model
+          </Button>
+        </CardActions>
       </Card>
     </Grid>
   );

--- a/apps/validation_framework_v2/src/ModelResultOverview.js
+++ b/apps/validation_framework_v2/src/ModelResultOverview.js
@@ -439,15 +439,14 @@ export default class ModelResultOverview extends React.Component {
             resultDetailOpen: true,
             currentResult: result,
         });
-        updateHash("result_id." + result.id);
     }
 
-    handleResultDetailClose() {
+    handleResultDetailClose(sourceHash) {
         this.setState({
             resultDetailOpen: false,
             currentResult: null,
         });
-        updateHash("");
+        updateHash(sourceHash || "" );
     }
 
     handleResultUpdate(updatedResult) {
@@ -596,7 +595,15 @@ export default class ModelResultOverview extends React.Component {
 
         const model_versions = this.getModelVersions();
         const results = this.props.results;
-        if (results.length === 0) {
+        if (!results) {
+            return (
+                <Typography variant="subtitle1">
+                    <b>
+                        Loading...
+                    </b>
+                </Typography>
+            );
+        } else if (results.length === 0) {
             content = this.renderNoResults();
         } else {
             const results_grouped = this.groupResults(model_versions, results);
@@ -613,6 +620,7 @@ export default class ModelResultOverview extends React.Component {
                     result={this.state.currentResult}
                     onClose={this.handleResultDetailClose}
                     onUpdate={this.handleResultUpdate}
+                    sourceHash={window.location.hash.slice(1)}
                 />
             );
         } else {

--- a/apps/validation_framework_v2/src/ResultDetail.js
+++ b/apps/validation_framework_v2/src/ResultDetail.js
@@ -21,6 +21,7 @@ import ResultDetailContent from "./ResultDetailContent";
 import ResultRelatedFiles from "./ResultRelatedFiles";
 import ResultModelTestInfo from "./ResultModelTestInfo";
 import { datastore } from "./datastore";
+import { updateHash } from "./globals";
 
 const styles = (theme) => ({
     root: {
@@ -89,11 +90,14 @@ export default class ResultDetail extends React.Component {
             tabValue: 0,
             auth: authContext,
             loading: true,
+            sourceHash: this.props.sourceHash || "" 
         };
 
         this.handleClose = this.handleClose.bind(this);
         this.handleTabChange = this.handleTabChange.bind(this);
         this.getResult = this.getResult.bind(this);
+
+        updateHash("result_id." + this.props.result.id);
 
         if (!this.props.result.model) {
             this.getResult(this.props.result.id);
@@ -139,7 +143,7 @@ export default class ResultDetail extends React.Component {
     }
 
     handleClose() {
-        this.props.onClose();
+        this.props.onClose(this.state.sourceHash);
     }
 
     handleTabChange(event, newValue) {
@@ -148,6 +152,7 @@ export default class ResultDetail extends React.Component {
 
     render() {
         let result = this.props.result;
+        console.log(JSON.parse(JSON.stringify(result)))
         if (!result.model) {
             result.model = {};
             result.model_instance = {};

--- a/apps/validation_framework_v2/src/ResultDetail.js
+++ b/apps/validation_framework_v2/src/ResultDetail.js
@@ -152,7 +152,6 @@ export default class ResultDetail extends React.Component {
 
     render() {
         let result = this.props.result;
-        console.log(JSON.parse(JSON.stringify(result)))
         if (!result.model) {
             result.model = {};
             result.model_instance = {};

--- a/apps/validation_framework_v2/src/ResultRelatedFiles.js
+++ b/apps/validation_framework_v2/src/ResultRelatedFiles.js
@@ -224,7 +224,15 @@ class ResultFile extends React.Component {
 
 class ResultRelatedFiles extends React.Component {
     render() {
-        if (this.props.result_files.length === 0) {
+        if (!this.props.result_files) {
+            return (
+                <Typography variant="subtitle1">
+                    <b>
+                        Loading...
+                    </b>
+                </Typography>
+            );
+        } else if (this.props.result_files.length === 0) {
             return (
                 <Typography variant="subtitle1">
                     <b>

--- a/apps/validation_framework_v2/src/TestResultOverview.js
+++ b/apps/validation_framework_v2/src/TestResultOverview.js
@@ -440,15 +440,14 @@ export default class TestResultOverview extends React.Component {
             resultDetailOpen: true,
             currentResult: result,
         });
-        updateHash("result_id." + result.id);
     }
 
-    handleResultDetailClose() {
+    handleResultDetailClose(sourceHash) {
         this.setState({
             resultDetailOpen: false,
             currentResult: null,
         });
-        updateHash("");
+        updateHash(sourceHash || "" );
     }
 
     handleResultUpdate(updatedResult) {
@@ -599,7 +598,15 @@ export default class TestResultOverview extends React.Component {
 
         const test_versions = this.getTestVersions();
         const results = this.props.results;
-        if (results.length === 0) {
+        if (!results) {
+            return (
+                <Typography variant="subtitle1">
+                    <b>
+                        Loading...
+                    </b>
+                </Typography>
+            );
+        } else if (results.length === 0) {
             content = this.renderNoResults();
         } else {
             const results_grouped = this.groupResults(test_versions, results);
@@ -616,6 +623,7 @@ export default class TestResultOverview extends React.Component {
                     result={this.state.currentResult}
                     onClose={this.handleResultDetailClose}
                     onUpdate={this.handleResultUpdate}
+                    sourceHash={window.location.hash.slice(1)}
                 />
             );
         } else {

--- a/apps/validation_framework_v2/src/datastore.js
+++ b/apps/validation_framework_v2/src/datastore.js
@@ -450,7 +450,10 @@ class DataStore {
     }
 
     async getResult(resultID, source = null) {
-        if (this.results[resultID]) {
+        if (this.results[resultID] && this.results[resultID].hasOwnProperty('model')) {
+            // results obtained via '/results-summary/' endpoint do not contain
+            // values for model, model_instance, test, test_instance, results_storage
+            // we fetch and store the detailed result JSON here
             return this.results[resultID];
         } else {
             const url = this.baseUrl + "/results-extended/" + resultID;


### PR DESCRIPTION
Currently, result details are not retrieved when results are accessed by clicking through models and tests. This is because these paths use the `/results-summary/` API end-point. Results obtained via `/results-summary/` endpoint do not contain values for model, model_instance, test, test_instance, results_storage. These need to be fetched from the `/results/` end-point.

(Currently we have proper working only when directly accessing a result via specifying the result UUID in the URL... in this case we do not use the models or tests path as above)

Also, currently when closing a result detail page, the URL hash was being set to "" without checking if it was arrived via a model or test page. This has been fixed to check the source path of arriving at the result detail page.